### PR TITLE
fix: allow the functions on Archive to be called multiple times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkiv"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Cédric Meuter <cedric.meuter@gmail.com>"]
 description = "library providing convenience function to manipulate various kind of archive (zip, tar.gz, tar.xz, ... )"

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -56,7 +56,9 @@ pub(crate) trait Archived {
 /// - `sample.tar.bz2` (requires `tar` and `bzip` features).
 /// - `sample.tar.zstd` or `sample.tar.zst` (requires `tar` and `zstd` features).
 pub struct Archive {
-    inner: Box<dyn Archived>,
+    path: PathBuf,
+    format: Format,
+    inner: Option<Box<dyn Archived>>,
 }
 
 impl Archive {
@@ -78,32 +80,57 @@ impl Archive {
     /// ```
     ///
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
-        let _file = File::open(&path)?;
-        let result: Result<Box<dyn Archived>> = match Format::infer_from_file_extension(path) {
+        let path = path.as_ref().to_path_buf();
+
+        let format = Format::infer_from_file_extension(&path);
+        if !format.is_archive() {
+            Err(Error::UnsupportedArchive(
+                "unsupported format, did you enable the proper feature?",
+            ))?;
+        }
+
+        let inner = None;
+
+        Ok(Archive {
+            path,
+            format,
+            inner,
+        })
+    }
+
+    fn inner(&mut self) -> Result<&mut Box<dyn Archived>> {
+        #[allow(unused)]
+        let file = File::open(&self.path)?;
+
+        let result: Result<Box<dyn Archived>> = match self.format {
             #[cfg(feature = "zip")]
-            Format::Zip => Ok(Box::new(Zip::new(_file)?)),
+            Format::Zip => Ok(Box::new(Zip::new(file)?)),
 
             #[cfg(feature = "tar")]
-            Format::Tar => Ok(Box::new(Tar::new(_file))),
+            Format::Tar => Ok(Box::new(Tar::new(file))),
 
             #[cfg(all(feature = "tar", feature = "gzip"))]
-            Format::TarGzip => Ok(Box::new(Tar::new(GzDecoder::new(_file)))),
+            Format::TarGzip => Ok(Box::new(Tar::new(GzDecoder::new(file)))),
 
             #[cfg(all(feature = "tar", feature = "bzip2"))]
-            Format::TarBzip2 => Ok(Box::new(Tar::new(BzDecoder::new(_file)))),
+            Format::TarBzip2 => Ok(Box::new(Tar::new(BzDecoder::new(file)))),
 
             #[cfg(all(feature = "tar", feature = "xz2"))]
-            Format::TarXz2 => Ok(Box::new(Tar::new(XzDecoder::new(_file)))),
+            Format::TarXz2 => Ok(Box::new(Tar::new(XzDecoder::new(file)))),
 
             #[cfg(all(feature = "tar", feature = "zstd"))]
-            Format::TarZstd => Ok(Box::new(Tar::new(ZstdDecoder::new(_file)?))),
+            Format::TarZstd => Ok(Box::new(Tar::new(ZstdDecoder::new(file)?))),
 
             _ => Err(Error::UnsupportedArchive(
                 "unsupported format, did you enable the proper feature?",
             )),
         };
 
-        result.map(|inner| Archive { inner })
+        self.inner.replace(result?);
+        Ok(self
+            .inner
+            .as_mut()
+            .expect("inner was freshly replaced, this should never happen"))
     }
 
     /// Returns the list of entries stored within the archive.
@@ -160,7 +187,7 @@ impl Archive {
     ///
     ///
     pub fn entries_iter(&mut self) -> Result<Entries> {
-        self.inner.entries()
+        self.inner()?.entries()
     }
 
     /// Unpacks the contents of the archive. On unix systems all permissions
@@ -182,6 +209,6 @@ impl Archive {
     /// }
     /// ```
     pub fn unpack(&mut self, dest: impl AsRef<Path>) -> Result<()> {
-        self.inner.unpack(dest.as_ref())
+        self.inner()?.unpack(dest.as_ref())
     }
 }

--- a/tests/entries.rs
+++ b/tests/entries.rs
@@ -13,6 +13,9 @@ fn test(path: impl AsRef<Path>) -> Result<()> {
     actual.sort();
     expected.sort();
 
+    /// call a second time to check that the rewind is done properly
+    assert!(archive.entries().is_ok());
+
     assert_eq!(actual, expected);
     Ok(())
 }

--- a/tests/entries_iter.rs
+++ b/tests/entries_iter.rs
@@ -16,6 +16,9 @@ fn test(path: impl AsRef<Path>) -> Result<()> {
         actual.push(path)
     }
 
+    /// call a second time to check that the rewind is done properly
+    assert!(archive.entries_iter().is_ok());
+
     actual.sort();
     expected.sort();
 

--- a/tests/unpack.rs
+++ b/tests/unpack.rs
@@ -15,6 +15,9 @@ fn test(path: impl AsRef<Path>) -> Result<()> {
         "sample\n"
     );
 
+    /// call a second time to check that the rewind is done properly
+    assert!(archive.unpack(&sandbox).is_ok());
+
     Ok(())
 }
 


### PR DESCRIPTION
fix: allow the functions on Archive to be called multiple times

(backport from `v0.5.x` branch)